### PR TITLE
fix: raise to new release-train fails if not enforced

### DIFF
--- a/.ivy/raise-deps.sh
+++ b/.ivy/raise-deps.sh
@@ -9,7 +9,8 @@ shopt -s globstar
 sed -i -E "s/(\"@axonivy[^\"]*\"): \"[^\"]*\"/\1: \"~${1/SNAPSHOT/next}\"/" package.json
 sed -i -E "s/(\"@axonivy[^\"]*\"): \"[^\"]*\"/\1: \"~${1/SNAPSHOT/next}\"/" extension/package.json
 sed -i -E "s/(\"@axonivy[^\"]*\"): \"[^\"]*\"/\1: \"~${1/SNAPSHOT/next}\"/" webviews/*/package.json
+
 npm run update:axonivy:next
 if [ "$DRY_RUN" = false ]; then
-  npm install
+  npm install --force
 fi


### PR DESCRIPTION
avoid raise problems: https://jenkins.ivyteam.io/job/github-repo-manager_raise-deps/job/master/616/console
![vsx-raise](https://github.com/user-attachments/assets/0f520a58-e1ab-4a72-b890-9539b8093841)
